### PR TITLE
fix: use absolute API path for image proxy

### DIFF
--- a/dashboard/api/vehicles.php
+++ b/dashboard/api/vehicles.php
@@ -202,7 +202,10 @@ foreach ($items as &$it) {
   }
   if ($it["img"]==="") {
     $imgUrl = image_from_detail($ad);
-    if ($imgUrl) $it["img"] = '/img.php?u=' . rawurlencode($imgUrl); // legacy param for maximum compatibility
+    if ($imgUrl) {
+      // Use absolute API path to avoid rewrite issues on deployment platforms
+      $it["img"] = '/api/img.php?src=' . rawurlencode($imgUrl);
+    }
   }
 }
 unset($it);


### PR DESCRIPTION
## Summary
- ensure vehicle images use absolute `/api/img.php` path to avoid rewrite issues

## Testing
- `php -l dashboard/api/vehicles.php`


------
https://chatgpt.com/codex/tasks/task_e_68c2064bfe74832dbe9b289b29f17fdd